### PR TITLE
feat: expose is_alive property on player scene

### DIFF
--- a/core/health/Health.gd
+++ b/core/health/Health.gd
@@ -8,7 +8,6 @@ signal depleted
 @export var max_health = 100
 @export var current: float = max_health
 
-	
 func heal(heal_points: float):
 	var health_after_heal = current + heal_points
 	if health_after_heal > max_health: 
@@ -22,9 +21,14 @@ func damage(damage_points: float):
 		else: current -= damage_points
 		
 		print_debug("current health " + str(current))
-		if current == 0 and is_mortal:
-			print_debug("died")
-			is_alive = false
-			depleted.emit()
+
+	if current == 0 and is_mortal:
+		kill()
 	
 func revive(): current = max_health
+
+func kill():
+	if is_alive:
+		print_debug("died")
+		is_alive = false
+		depleted.emit()

--- a/player/scouter/Player.gd
+++ b/player/scouter/Player.gd
@@ -11,6 +11,7 @@ signal player_has_died
 
 @export var speed = 400.0
 @export var max_health = 110
+@export var is_alive = true
 
 var _currentDirectionVector: Vector2 = Vector2.ZERO 
 var _lastDirection: PLAYER_DIRECTION = PLAYER_DIRECTION.RIGHT
@@ -24,7 +25,7 @@ func _ready() -> void :
 	connect("player_position_update", melee_attack._on_player_position_update)
 
 func _process(_delta: float) -> void:
-	if health.is_alive:
+	if is_alive:
 		_animate()
 		_update_sprite_direction()
 		
@@ -36,10 +37,11 @@ func _process(_delta: float) -> void:
 			if melee_attack.get_parent() != null:
 				remove_child(melee_attack)
 	else:
+		health.kill()
 		animated_sprite.pause()
 
 func _physics_process(_delta: float) -> void:
-	if health.is_alive:
+	if is_alive:
 		_move_player()
 	
 func _move_player():


### PR DESCRIPTION
### PR Description
This PR exposes the is_alive property from health. This enables killing a character from the editor. Is useful for debugging.
<img width="295" alt="Screenshot 2024-09-02 at 23 41 26" src="https://github.com/user-attachments/assets/61e9bf56-23fd-4e2c-af61-219b2646fcc7">

Also it adds the kill function to Health scene. It's useful to deplate the health and trigger the appropriate signals.

how to use:
`$Health.kill()`


