### PR TITLE
fix: window resize

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -23,7 +23,7 @@ window/size/viewport_height=240
 window/size/window_width_override=1920
 window/size/window_height_override=1090
 window/stretch/mode="viewport"
-window/stretch/aspect="ignore"
+window/stretch/aspect="keep_height"
 
 [input]
 


### PR DESCRIPTION
This PR fixes the window resizing.

The game wasn't keeping it's aspect ratio on resizes. Now the window will strech keeping the aspect ration. This will fix jittering the pixel art after resizing the window.

Before

https://github.com/user-attachments/assets/7b915c89-4f3e-4af2-864f-72c8586eb42f

After

https://github.com/user-attachments/assets/07d1bf2f-90b9-4a87-a6a5-82004f918ffd

