### PR TITLE
Scale down damage and health

### DIFF
--- a/core/HitBox.gd
+++ b/core/HitBox.gd
@@ -1,4 +1,4 @@
 class_name HitBox
 extends Area2D
 
-@export var damage := 10.0
+@export var damage := 1.0

--- a/npcs/creeper/Creeper.gd
+++ b/npcs/creeper/Creeper.gd
@@ -4,8 +4,8 @@ const NODE_NAME = "Creeper"
 
 @export var speed: float = 80
 @export var line_of_sight_size: float = 150.0
-@export var max_health: float = 30.0
-@export var damage: float = 30.0
+@export var max_health: float = 3.0
+@export var damage: float = 3.0
 
 @onready var line_of_sight_area: CircleShape2D =  $EngageArea/CollisionShape2D.shape as CircleShape2D
 @onready var collisionShape: CollisionShape2D = $CollisionShape2D
@@ -16,7 +16,7 @@ var player_los: bool = false
 
 func die() -> void:
 	queue_free()
-	print_debug("enemy_died")
+	print_debug("a creeper has died")
 
 func _ready() -> void:
 	set_collision_layer_value(1, false)

--- a/player/scouter/Player.gd
+++ b/player/scouter/Player.gd
@@ -3,7 +3,6 @@ enum PLAYER_DIRECTION { LEFT, TOP, RIGHT, BOTTOM }
 
 signal changed_direction(PLAYER_DIRECTION)
 signal player_position_update(Vector2)
-signal player_has_died
 
 @onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var playerArea: CollisionShape2D = $PlayerArea/CollisionShape2D
@@ -16,6 +15,9 @@ signal player_has_died
 var _currentDirectionVector: Vector2 = Vector2.ZERO 
 var _lastDirection: PLAYER_DIRECTION = PLAYER_DIRECTION.RIGHT
 var melee_attack: Area2D
+
+func take_damage(damage: float):
+	health.damage(damage)
 
 func _ready() -> void : 
 	melee_attack = preload("res://weapons/melee_attack.tscn").instantiate()
@@ -81,9 +83,6 @@ func get_current_direction() -> PLAYER_DIRECTION:
 		playerDirection = PLAYER_DIRECTION.BOTTOM
 	
 	return playerDirection; 
-			
-func take_damage(damage: float):
-	health.damage(damage)
 	
 func _on_health_depleted():
 	print_debug("player has died")


### PR DESCRIPTION
This PR scales down Health and Damage. This still can be changed through customization.

Objective:
- This could contribute to easier adjustments on the game design (Simplify my maths 🤓 )
-  Could help improving to give the player a notion of a more tatical gameplay
- It helps to create shorter combats sequence
