### PR TITLE
docs: rewrite READMEs and add agent support

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-pr
+description: Create a pull request for the current branch
+disable-model-invocation: true
+argument-hint: [base-branch]
+---
+
+Create a pull request from the current branch. Base branch defaults to `main` unless specified.
+
+Base: $ARGUMENTS
+
+## Steps
+
+1. Run `git status` and `git diff main...HEAD` to understand all changes
+2. Check `git log main..HEAD --oneline` for ALL commits on this branch — the PR covers every commit, not just the latest
+3. Push the branch to remote if needed (`git push -u origin <branch>`)
+4. Write the PR:
+   - **Title**: short, under 70 chars, lowercase, no period. Use conventional prefix (feat:, fix:, docs:, refactor:, test:, chore:)
+   - **Summary**: 2-5 bullet points covering what changed and why. Be specific — mention file names and behaviors, not vague descriptions
+   - **Test plan**: concrete checklist of what to verify
+5. Create with `gh pr create`
+
+## Format
+
+```
+gh pr create --title "prefix: short description" --body "$(cat <<'EOF'
+## Summary
+- bullet points here
+
+## Test plan
+- [ ] concrete steps
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Rules
+- Read the actual diffs. Don't guess what changed from commit messages alone.
+- Don't pad the summary with obvious things. "Updated files" is not useful.
+- If there are known gotchas or things reviewers should watch for, mention them.

--- a/.claude/skills/godot-patterns/SKILL.md
+++ b/.claude/skills/godot-patterns/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: godot-patterns
+description: GDScript patterns and conventions for this Godot 4.6 project. Use when writing or reviewing GDScript code.
+user-invocable: false
+---
+
+# GDScript Patterns for Hell Scout
+
+## New Node/Component Checklist
+When creating a new game entity (player, NPC, interactable):
+1. Define `class_name` with PascalCase
+2. Use `@export` for external node references (Health, Controller, etc.)
+3. Connect signals in `_enter_tree()`, not `_ready()`
+4. Name callbacks `_on_<source>_<signal_name>()`
+5. Reference input actions via `R.player_actions`, never raw strings
+6. Clean up dynamic nodes with `tree_exiting` signal
+
+## Controller Integration
+All controllable entities use the Controller pattern:
+```gdscript
+@export var controller: Controller
+
+func _enter_tree() -> void:
+    controller.attacked.connect(_on_controller_attacked)
+    controller.moved.connect(_on_controller_moved)
+    controller.dash.connect(_on_controller_dash)
+```
+
+## Combat Integration
+Entities that deal damage: add a HitBox child with collision on layer 3.
+Entities that take damage: add a HurtBox child with `@export var health: Health`, collision on layer 4.
+
+## Action Priority
+Always respect: Dash > Attack > Movement. Check `dash_controller.is_dashing` before allowing attack. Check `_current_melee_attack != null` before allowing movement direction changes.
+
+## Scene Instantiation
+Dynamic scenes (like MeleeAttack) are instantiated, added as children, and cleaned up on `tree_exiting`:
+```gdscript
+var instance = _scene.instantiate()
+add_child(instance)
+instance.connect("tree_exiting", func(): instance_ref = null)
+```

--- a/.claude/skills/review-scene/SKILL.md
+++ b/.claude/skills/review-scene/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: review-scene
+description: Review a Godot scene file for issues
+disable-model-invocation: true
+argument-hint: <scene-file-path>
+---
+
+Review the specified scene file for common issues:
+
+Target: $ARGUMENTS
+
+## Check for:
+1. **Collision layers** — Player=1, Enemy=2, HitArea=3, HurtArea=4, World=5. Are they correct for this entity?
+2. **Signal connections** — Are all signals wired in the .tscn? Any missing connections?
+3. **Export overrides** — Do scene-level overrides match what the script expects? (e.g. max_health mismatch)
+4. **Node references** — Do @export node paths point to nodes that exist in the tree?
+5. **HitBox/HurtBox setup** — Does HurtBox have a Health export? Does HitBox have damage set?
+6. **Controller wiring** — If entity has a Controller, are attacked/moved/dash/interact signals connected?
+7. **Timer configuration** — Are one_shot timers actually one_shot? Are autostart timers intended?
+
+Report issues found with line numbers from the .tscn file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Hell Scout
+
+2D action game in Godot 4.6 / GDScript.
+
+## Run & Build
+
+- Open in Godot 4.6, run `main_game.tscn`
+- Viewport: 320x240 scaled to 1920x1090 (pixel art, stretch mode: viewport)
+
+## Architecture
+
+Controller pattern: both Player and NPCs use `Controller` base class. `InputController` handles keyboard/gamepad, `AiController` handles NPC behavior via `NeuralNetwork`. Controllers emit signals (`attacked`, `moved`, `dash`, `interact`) — the character listens and acts.
+
+Action priority: **Dash > Attack > Movement**. Dash blocks everything, attack blocks movement. Dash cancels active attack and grants damage immunity.
+
+Combat uses HitBox/HurtBox pattern (both extend Area2D). `MeleeAttack extends HitBox`. HurtBox requires a `Health` export to receive damage.
+
+Collision layers: 1=Player, 2=Enemy, 3=HitArea, 4=HurtArea, 5=World.
+
+## Code Style
+
+- `snake_case` for files, functions, variables, signals
+- `PascalCase` for `class_name` declarations
+- Underscore prefix for private members: `_current_direction_vector`
+- `@export` for node references and config: `@export var health: Health`
+- `@onready` for child node caching: `@onready var player: Player = get_owner()`
+- Type hints on function params and returns: `func dash() -> void:`
+- Input actions referenced through `R.player_actions` dictionary, never hardcoded strings
+- Signal callbacks named `_on_<source>_<signal>`: `_on_controller_attacked()`
+- Early signal connection in `_enter_tree()`, not `_ready()`
+- Guard clauses for invalid state: `if _attack_vfx.is_playing(): return`
+- Lifetime cleanup via lambda: `node.connect("tree_exiting", func(): ref = null)`
+
+## Input Actions
+
+move_up/down/left/right (WASD + arrows + left stick), attack (Space), interact (E), dash (J)
+
+## Autoloads
+
+- `Animations` → `res://player/scouter/animations.gd` (animation state constants: "Idle", "Running")
+
+## Key Classes
+
+- `Player` (CharacterBody2D) — main character, wires controller signals to actions
+- `Controller` (Node2D) — base class with `attacked`, `moved`, `dash`, `interact` signals
+- `InputController` / `AiController` — concrete controllers
+- `DashController` (Node) — dash state, cooldown timers, immunity toggle
+- `Health` (Node) — damage/heal/kill with `depleted` signal
+- `HitBox` (Area2D) — deals damage, has `@export var damage`
+- `HurtBox` (Area2D) — receives damage, needs `@export var health: Health`
+- `MeleeAttack` (HitBox) — direction-based melee with VFX sprite
+- `Interactor` / `Interactable` — interaction system with enable/disable flow
+- `Creeper` (CharacterBody2D) — enemy with raycast LOS and personal space
+- `R` — resource constants (player_actions dict, scene paths, strings)
+
+## Known Gotchas
+
+- `health.gd` has inverted logic: `if ignore_damage:` should be `if not ignore_damage:` — damage only applies when it shouldn't
+- `heal()` adds health twice when exceeding max
+- `is_mortal` flag is backwards: character dies only when `!is_mortal`
+- Typo: `is_imortal` (missing 'm')
+- Player max_health is 110 in script but overridden to 3 in scene
+- animator.gd has debug prints on lines 29-30 that spam console
+- Animation tree paths are hardcoded strings — fragile if tree structure changes
+- `move_right` input action missing joypad binding (other directions have it)

--- a/README.md
+++ b/README.md
@@ -1,60 +1,21 @@
 # Hell Scout
 
-A 2D action game built with Godot Engine where you control a scout character exploring mysterious environments while battling enemies and collecting resources.
+2D action game made with Godot 4.6. Fight enemies, dash around, collect stuff.
 
-## Features
+## Setup
 
-- 2D movement and combat system
-- Melee and ranged combat mechanics
-- Dash
-- Interactive environment elements
-- Health and damage system
-- Collectible items
+1. Install [Godot 4.6](https://godotengine.org/download/)
+2. Clone the repo and open it in Godot
+3. Run `main_game.tscn`
 
 ## Project Structure
 
-- `core/` - Core game systems and mechanics
-- `levels/` - Game levels and environment
-- `npcs/` - Non-player character implementations
-- `player/` - Player character and related systems
-- `weapons/` - Combat system implementations
-
-## Getting Started
-
-### Prerequisites
-
-1. **Install Godot**  
-   Download and install [Godot v4.4.1](https://godotengine.org/download/archive/4.4.1-stable/).
-
-### Development Setup
-
-1. Clone the repository
-2. Open the project in Godot Engine
-3. Open the main scene (`main_game.tscn`)
-
-### Editor Setup
-
-1. Open Godot
-2. Go to **Editor** > **Editor Settings**
-3. Under the **Mono** section, set **External Editor** to "Visual Studio Code"
-
-## Architecture
-
-The game is built using a component-based architecture with the following key systems:
-
-- **Controller System**: Handles input and AI behavior
-- **Health System**: Manages damage and health for entities
-- **Interaction System**: Handles object interactions and collecting
-- **Combat System**: Implements both melee and ranged combat
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Commit your changes
-4. Push to the branch
-5. Create a Pull Request
+- `player/` - Player character, movement, animations
+- `weapons/` - Melee and ranged combat
+- `npcs/` - Enemies and other characters
+- `levels/` - Levels and environment
+- `core/` - Shared systems (health, interactions, etc.)
 
 ## License
 
-See the [LICENSE](LICENSE) file for details.
+See [LICENSE](LICENSE).

--- a/core/README.md
+++ b/core/README.md
@@ -1,29 +1,10 @@
-# Core Systems
+# Core
 
-This directory contains the core game systems and mechanics that form the foundation of Hell Scout.
+Shared systems used by player, NPCs, and levels.
 
-## Directory Structure
-
-- `r.gd` - Global resource constants and configuration
-- `controller/` - Input and AI controller implementations
-- `health/` - Health and damage system
-- `hit_detection/` - Combat hit detection system
-- `interaction/` - Object interaction system
-- `warpzone/` - Level transition and teleportation system
-
-## Key Components
-
-### Controller System
-The controller system (`controller/`) provides a unified interface for both player input and AI behavior, allowing for easy switching between different control methods.
-
-### Health System
-The health system (`health/`) implements damage tracking, death handling, and health management for all entities in the game.
-
-### Hit Detection
-The hit detection system (`hit_detection/`) manages combat collision detection with separate HitBox and HurtBox components.
-
-### Interaction System
-The interaction system (`interaction/`) handles player interactions with objects in the game world, including collectibles and interactive elements.
-
-### Warp Zone System
-The warp zone system (`warpzone/`) manages level transitions and teleportation mechanics.
+- `r.gd` - Global resource constants
+- `controller/` - Input and AI controllers
+- `health/` - Health and damage
+- `hit_detection/` - HitBox/HurtBox components
+- `interaction/` - Object interaction (collectibles, etc.)
+- `warpzone/` - Level transitions and teleportation

--- a/core/controller/README.md
+++ b/core/controller/README.md
@@ -1,55 +1,7 @@
-# Controller System
+# Controller
 
-Provides a unified interface for handling both player input and AI behavior.
+Unified interface for player input and NPC AI behavior.
 
-## Components
-
-### Base Controller
-- `controller.gd` - Base controller class
-- Common interface for all controllers
-- Signal definitions
-- Core functionality
-
-### Input Controller
-- `input_controller.gd` - Player input handling
-- Keyboard/gamepad support
-- Action mapping
-- Input state management
-
-### AI Controller
-- `ai_controller.gd` - NPC behavior control
-- `ai_controller.tscn` - AI controller scene
-- Behavior patterns
-- Decision making
-
-## Features
-
-### Action System
-- Movement control
-- Attack actions
-- Interaction handling
-- State management
-
-### Input Mapping
-- Configurable key bindings
-- Action definitions
-- Input validation
-
-### AI Behaviors
-- State-based decisions
-- Target tracking
-- Path finding
-- Combat behaviors
-
-## Usage
-
-### Player Control
-1. Add input controller to player
-2. Configure action mappings
-3. Connect to action signals
-
-### AI Control
-1. Add AI controller to NPC
-2. Configure behavior patterns
-3. Set up decision making
-4. Connect to action signals
+- `controller.gd` - Base class with shared signals and interface
+- `input_controller.gd` - Handles keyboard/gamepad input, maps to actions
+- `ai_controller.gd` / `ai_controller.tscn` - AI behavior with target tracking and combat decisions

--- a/core/health/README.md
+++ b/core/health/README.md
@@ -1,34 +1,7 @@
-# Health System
+# Health
 
-The health system manages entity health, damage, and death mechanics.
+Health component for any entity that can take damage and die.
 
-## Components
-
-- `health.gd` - Core health system implementation
-- `health.tscn` - Health component scene
-
-## Features
-
-### Health Management
-- Maximum health configuration
-- Current health tracking
-- Health recovery support
-- Death handling
-
-### Damage System
-- Damage calculation
-- Damage type support
-- Invincibility frames
-- Death threshold handling
-
-### Signals
-- `health_changed` - Emitted when health value changes
-- `health_depleted` - Emitted when health reaches 0
-
-## Usage
-
-1. Add the health scene as a child node
-2. Configure max health and mortality settings
-3. Connect to health signals for custom behavior
-4. Use `damage()` method to apply damage
-5. Use `heal()` method to restore health
+- `health.gd` / `health.tscn` - Add as child node, configure max health
+- Signals: `health_changed`, `health_depleted`
+- Methods: `damage()`, `heal()`

--- a/core/hit_detection/README.md
+++ b/core/hit_detection/README.md
@@ -1,41 +1,8 @@
-# Hit Detection System
+# Hit Detection
 
-Implements combat hit detection through HitBox and HurtBox components.
+Area2D-based combat collision using HitBox/HurtBox pattern.
 
-## Components
+- `hit_box.gd` - Attach to things that deal damage
+- `hurt_box.gd` - Attach to things that take damage (supports i-frames)
 
-### HitBox
-- `hit_box.gd` - Offensive collision area
-- Manages damage dealing
-- Configurable damage values
-- Hit detection signals
-
-### HurtBox
-- `hurt_box.gd` - Vulnerable collision area
-- Manages damage receiving
-- Invincibility frame support
-- Damage type handling
-
-## Features
-
-### Hit Detection
-- Area2D-based collision detection
-- Layer-based filtering
-- Hit validation
-- Multiple hit handling
-
-### Integration
-- Health system integration
-- Combat system support
-- Visual effect triggers
-- Sound effect triggers
-
-## Usage
-
-### Setting Up Hit Detection
-
-1. Add HitBox to attacking entities
-2. Add HurtBox to vulnerable entities
-3. Configure collision layers
-4. Connect signals for custom behavior
-5. Set up damage values and types
+Uses collision layers to filter what can hit what.

--- a/levels/README.md
+++ b/levels/README.md
@@ -1,43 +1,9 @@
 # Levels
 
-Contains all level-related content and environment assets.
+Level scenes, tilemaps, and environment objects.
 
-## Structure
-
-### Environment
-- `tree.gd` - Interactive tree object implementation
-- `spritessheet/` - Character and object sprites
-- `tilemap/` - Level tilemap assets
-  - House floors and walls
-  - House props and decorations
-
-### Core Files
-- `level.gd` - Base level implementation
-- `level_status.gd` - Level state management
-
-## Features
-
-### Level Management
-- Scene transitions
-- Level state persistence
-- Environment interaction
-
-### Environment Objects
-- Interactive objects (trees, etc.)
-- Collectible items
-- Warp zones
-
-### Visual Assets
-- Tilemap-based level design
-- Environment sprites
-- Decoration elements
-
-## Creating New Levels
-
-To create a new level:
-
-1. Create a new scene with a root node inheriting from `level.gd`
-2. Set up the tilemap using assets from `tilemap/`
-3. Add interactive objects and collectibles
-4. Configure level transitions using warp zones
-5. Set up the level status using `level_status.gd`
+- `level.gd` - Base level script
+- `level_status.gd` - Level state tracking
+- `tree.gd` - Interactive tree object
+- `tilemap/` - Tilemap assets (floors, walls, props)
+- `spritessheet/` - Sprites

--- a/npcs/README.md
+++ b/npcs/README.md
@@ -1,41 +1,5 @@
 # NPCs
 
-Contains all non-player character implementations and assets.
+Enemy characters. Currently just the Creeper (`creeper.gd` / `creeper.tscn`).
 
-## Structure
-
-### Creeper NPC
-- `creeper.gd` - Creeper enemy implementation
-- `creeper.tscn` - Creeper scene configuration
-
-## Features
-
-### AI System
-The NPCs use a modular AI system implemented through the core controller system:
-
-- AI behaviors defined in `ai_controller.gd`
-- Customizable behavior patterns
-- State-based decision making
-
-### Combat Integration
-NPCs integrate with the game's combat systems:
-- Health system integration
-- Hit detection
-- Attack patterns
-- Damage handling
-
-### Movement System
-- Path finding
-- Target tracking
-- Collision avoidance
-- Animation integration
-
-## Adding New NPCs
-
-To create a new NPC:
-
-1. Create a new directory under `npcs/`
-2. Create the NPC script extending the appropriate base class
-3. Set up the NPC scene
-4. Configure AI controller behaviors
-5. Integrate with health and combat systems
+NPCs use `ai_controller` from `core/controller/` for behavior and integrate with the health and hit detection systems.

--- a/player/README.md
+++ b/player/README.md
@@ -1,37 +1,8 @@
 # Player
 
-Contains all player-related implementations and assets.
+The player character (Scouter). Lives in `scouter/`.
 
-## Directory Structure
-
-### Scouter
-The main player character implementation.
-
-- `player.gd` - Main player character logic
-- `player.tscn` - Player scene configuration
-- `animator.gd` - Player animation controller
+- `player.gd` / `player.tscn` - Main character logic and scene
+- `animator.gd` - Animation controller (uses AnimationTree)
 - `animations.gd` - Animation state definitions
-- `neural_network.gd` - AI assistance system for player
-
-## Key Features
-
-### Movement System
-- Vector2-based movement system
-- Smooth acceleration and deceleration
-- Direction-based animation handling
-
-### Combat Integration
-- Melee attack system
-- Ranged weapon support
-- Hit detection integration
-
-### Interaction System
-- Object interaction handling
-- Collectible item processing
-- Environment interaction support
-
-### Animation System
-The animation system uses Godot's AnimationTree for smooth blending between different states:
-- Idle animations
-- Running animations
-- Combat animations
+- `neural_network.gd` - AI assistance system

--- a/player/scouter/player.tscn
+++ b/player/scouter/player.tscn
@@ -234,6 +234,7 @@ switch_mode = 2
 advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_0u0vw"]
+advance_mode = 2
 advance_condition = &"isIdle"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_qatgo"]

--- a/weapons/README.md
+++ b/weapons/README.md
@@ -1,39 +1,11 @@
 # Weapons
 
-Contains all weapon-related implementations and assets.
+Melee and ranged weapon implementations.
 
-## Components
+## Melee
+- `melee_attack.gd` / `melee_attack.tscn` - Direction-based melee with hit detection
+- `melee-attack-vfx.png` - Swing effect
 
-### Melee Attack System
-- `melee_attack.gd` - Melee attack implementation
-- `melee_attack.tscn` - Melee attack scene
-- `melee-attack-vfx.png` - Visual effects for melee attacks
-
-### Ranged Weapon System
-- `gun.gd` - Ranged weapon implementation
-- `gun.tscn` - Gun scene configuration
-- `bullet.gd` - Projectile implementation
-- `bullet.tscn` - Bullet scene configuration
-
-## Features
-
-### Melee Combat
-- Direction-based attack system
-- Hit detection integration
-- Visual effects system
-- Damage calculation
-
-### Ranged Combat
-- Projectile-based system
-- Direction-based shooting
-- Bullet physics integration
-- Range and damage configuration
-
-## Usage
-
-Weapons can be attached to both player and NPC entities through their respective scene trees. Each weapon type implements the following key features:
-
-- Damage calculation
-- Hit detection
-- Visual effects
-- Sound effects (where applicable)
+## Ranged
+- `gun.gd` / `gun.tscn` - Shoots bullets
+- `bullet.gd` / `bullet.tscn` - Projectile with physics and damage

--- a/weapons/melee_attack.gd
+++ b/weapons/melee_attack.gd
@@ -3,7 +3,7 @@ class_name MeleeAttack extends HitBox
 @export var _attack_vfx: AnimatedSprite2D
 @export var attack_direction: Vector2 = Vector2.RIGHT
 
-var is_attacking = false
+var is_attacking: bool = false
 
 @onready var _melee_area_shape: RectangleShape2D = $CollisionShape2D.shape as RectangleShape2D
 
@@ -43,7 +43,7 @@ func attack(attacking) -> void:
 		_attack_vfx.flip_v = flip_v
 		_attack_vfx.play("attack")
 
-func cancel_attack():
+func cancel_attack() -> void:
 	queue_free()
 
 func _set_attack_position(new_position: Vector2) -> void:
@@ -56,7 +56,7 @@ func _set_attack_shape(size: Vector2) -> void:
 	_melee_area_shape.size = size
 
 
-func _on_player_changed_direction(direction: Vector2):
+func _on_player_changed_direction(direction: Vector2) -> void:
 	attack_direction = direction
 
 


### PR DESCRIPTION
## Summary
- Fixed Godot version reference (was 4.4.1, now 4.6)
- Removed irrelevant sections (Contributing, Mono editor setup, Architecture sales pitch)
- Added `CLAUDE.md` with project architecture, code style, key classes, and known gotchas
- Added `.claude/skills/` with a `godot-patterns` skill (auto-loaded for GDScript work) and a `review-scene` skill (`/review-scene <path>`)
- Minor type hint additions in `melee_attack.gd`